### PR TITLE
Fixed a bug with projectiles being stuck in overlapping time walls

### DIFF
--- a/Assets/C#/PlayerScripts/PlayerAbilities/BaseProjectiles/Projectile.cs
+++ b/Assets/C#/PlayerScripts/PlayerAbilities/BaseProjectiles/Projectile.cs
@@ -18,6 +18,7 @@ public class Projectile : MonoBehaviour {
     public float lifetime = 10;
     public PlayerEffects.Effects effect;
     public float effectDuration = 3;
+    public float currentVelocity = 0;
 
     private bool hasHit;
 
@@ -25,6 +26,7 @@ public class Projectile : MonoBehaviour {
 
     void Start() {
         Invoke("DestroyMe", lifetime);
+        currentVelocity = this.GetComponent<Rigidbody>().velocity.magnitude;
     }
 
     void DestroyMe()

--- a/Assets/C#/PlayerScripts/PlayerAbilities/BaseProjectiles/Projectile_Accelerating.cs
+++ b/Assets/C#/PlayerScripts/PlayerAbilities/BaseProjectiles/Projectile_Accelerating.cs
@@ -9,10 +9,14 @@ public class Projectile_Accelerating : Projectile {
 
     void Start() {
         myRigid = this.GetComponent<Rigidbody>();
+        currentVelocity = myRigid.velocity.magnitude;
     }
     // Update is called once per frame
     void Update () {
         if (myRigid.velocity.magnitude < maxVelocity)
+        {
             myRigid.AddForce(myRigid.velocity * Mathf.Pow(myRigid.velocity.magnitude, 2) * speedMultiplier * Time.deltaTime);
+            currentVelocity = myRigid.velocity.magnitude;
+        }
 	}
 }

--- a/Assets/C#/PlayerScripts/PlayerAbilities/TimeWall/TimeWall.cs
+++ b/Assets/C#/PlayerScripts/PlayerAbilities/TimeWall/TimeWall.cs
@@ -27,16 +27,20 @@ public class TimeWall : MonoBehaviour {
             if((r = col.GetComponent<Rigidbody>()) != null)
             {
                 hitByThese.Add(r);
-                magnitudes.Add(Vector3.Magnitude(r.velocity));
                 r.AddForce(-(r.velocity), ForceMode.VelocityChange);
             }
             Projectile p;
             if (p = r.transform.GetComponent<Projectile>())
             {
+                magnitudes.Add(p.currentVelocity);
                 p.sourcePlayer = ability.gameObject;
                 p.CancelInvoke("DestroyMe");
                 p.Invoke("DestroyMe", p.lifetime);
+            }else
+            {
+                magnitudes.Add(Vector3.Magnitude(r.velocity));
             }
+
             return;
         }
     }


### PR DESCRIPTION
So the problem was that if there was a projectile in a time wall, that then was put into another time wall, the second time wall would percieve the projectile's velocity to be 0, so this change just creates a variable for projectiles called current velocity, whose implementation fixes the aforementioned problem.  Also, I have tested this with multiple different time players by myself, and there seemed to be no issues with the changes.  This should be the last bug that needed fixing for the time wall ability.